### PR TITLE
Feat/DTO fixes

### DIFF
--- a/src/api/dto/Ingredient.js
+++ b/src/api/dto/Ingredient.js
@@ -15,7 +15,7 @@ export default class Ingredient {
     this.amount = amount;
     this.unit = unit;
 
-    if (optional.id) this.id = optional.id;
+    if (optional && optional.id) this.id = optional.id;
   }
 
   /**

--- a/src/api/dto/Ingredient.js
+++ b/src/api/dto/Ingredient.js
@@ -3,15 +3,15 @@ export default class Ingredient {
    * A field of the `Recipe` class.
    *
    * @param {string} name - Name of the ingredient
-   * @param {number} amount - Amount required
-   * @param {string} unit - Unit of measurement
+   * @param {number} amount - Amount of the ingredient (can be `null`)
+   * @param {string} unit - Unit of measurement (or `""` if `amount` is abscent)
    * @param {Object} [optional] - Optional fields
    * @param {string} [optional.id] - ID returned from API on GET
    */
   constructor(name, amount, unit, optional = {}) {
-    if (!(name && amount && unit))
-      throw new Error("`name`, `amount`, and `unit` are required");
+    if (!name) throw new Error("`name` is required");
     this.name = name;
+
     this.amount = amount;
     this.unit = unit;
 

--- a/src/api/dto/Recipe.js
+++ b/src/api/dto/Recipe.js
@@ -26,8 +26,8 @@ export default class Recipe {
     instructions,
     optional = {},
   ) {
-    if (!(name && description && imageUrl))
-      throw new Error("`title`, `description`, and `imageUrl` are required");
+    if (!(name && description))
+      throw new Error("`title` and `description` are required");
     if (
       !ingredients ||
       !Array.isArray(ingredients.items) ||

--- a/src/api/dto/Recipe.js
+++ b/src/api/dto/Recipe.js
@@ -50,9 +50,11 @@ export default class Recipe {
     this.instructions = instructions;
     this.categories = categories;
 
-    if (optional.id) this.id = optional.id;
-    if (optional.avgRating !== undefined) this.avgRating = optional.avgRating;
-    if (optional.ratings !== undefined) this.ratings = optional.ratings;
+    if (optional) {
+      if (optional.id) this.id = optional.id;
+      if (optional.avgRating !== undefined) this.avgRating = optional.avgRating;
+      if (optional.ratings !== undefined) this.ratings = optional.ratings;
+    }
   }
 
   /**


### PR DESCRIPTION
# Changes
## Recipe
Allow the `.imageUrl` attribute to be assigned `""` (or other `false` values).
## Ingredient
Allow the `.amount` attribute to be assigned `null` (or other `false` values).
Allow the `.unit` attribute to be assigned `""` (or other `false` values).
# Fixes
Added checks for the presence `optional` argument before attempting to use fields of said object.