### PR TITLE
Fix title display in RecipeCard

### DIFF
--- a/src/components/RecipeCard.jsx
+++ b/src/components/RecipeCard.jsx
@@ -1,12 +1,12 @@
 export default function RecipeCard({ recipe }) {
   if (!recipe) return <div>No recipe found</div>;
 
-  const { title, imageUrl, avgRating, timeInMins, ingredients } = recipe;
+  const { name, imageUrl, avgRating, timeInMins, ingredients } = recipe;
 
   return (
     <div>
-      <h2>{title}</h2>
-      <img src={imageUrl || "/placeholder.jpg"} alt={title || "Recipe image"} />
+      <h2>{name}</h2>
+      <img src={imageUrl || "/placeholder.jpg"} alt={name || "Recipe image"} />
       <p>Rating: {avgRating ?? "No rating yet"}</p>
       <p>Time: {timeInMins ? `${timeInMins} minutes` : "Unknown time"}</p>
       <p>Number of ingredients: {ingredients?.length ?? 0}</p>


### PR DESCRIPTION
**Title could not be displayed due to:**

Recipe.js was sending **name** instead of **title**.
This PR updates RecipeCard to use **name** instead of **title** to correctly display the recipe title.