### PR TITLE
chore(api): fix JSDoc return type

### DIFF
--- a/src/api/connection.js
+++ b/src/api/connection.js
@@ -56,7 +56,7 @@ export async function getCategories() {
  * Fetch categories as a hierarchically.
  *
  * @async
- * @returns {Object<string, Array<string>>} Category hierarchy.
+ * @returns {Promise<Object<string, Array<string>>>} Category hierarchy.
  */
 export async function getCategoryHierarchy() {
   let categoryHierarchy = {};


### PR DESCRIPTION
Yet another JSDoc fix.
Added another function for fetching data from the API, but the JSDoc of said function had faulty documentation.